### PR TITLE
Harden run_audit.sh OS detection with BENCHMARK_OS fallback

### DIFF
--- a/run_audit.sh
+++ b/run_audit.sh
@@ -89,7 +89,7 @@ fi
 # Define os_vendor variable
 # Use /etc/os-release as primary source (works in containers where uname/hostnamectl may fail)
 if [ -f /etc/os-release ]; then
-  os_id="$(grep -w "^ID=" /etc/os-release | cut -d= -f2 | tr -d '"' | awk '{print tolower($0)}')"
+  os_id="$(grep "^ID=" /etc/os-release | cut -d= -f2 | tr -d '"' | awk '{print tolower($0)}')"
   case "$os_id" in
     amzn) os_vendor="AMAZON" ;;
     rhel|ol|oracle|rocky|almalinux|centos) os_vendor="RHEL" ;;
@@ -107,7 +107,21 @@ else
   fi
 fi
 
-os_maj_ver="$(grep -w VERSION_ID= /etc/os-release | awk -F\" '{print $2}' | cut -d '.' -f1)"
+os_maj_ver="$(grep "^VERSION_ID=" /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d '.' -f1)"
+
+# Fallback to BENCHMARK_OS constants if detection produced empty results.
+# This audit is single-OS by design (BENCHMARK_OS hardcoded above); detection
+# is a sanity check, not a load-bearing identifier. Pathological /etc/os-release
+# (missing ID=, missing VERSION_ID=, etc.) must not silently produce wrong paths.
+if [ -z "$os_vendor" ]; then
+  os_vendor="${BENCHMARK_OS//[0-9]/}"
+  echo "WARNING - OS vendor detection produced empty result; falling back to BENCHMARK_OS vendor=${os_vendor}"
+fi
+if [ -z "$os_maj_ver" ]; then
+  os_maj_ver="${BENCHMARK_OS//[A-Za-z]/}"
+  echo "WARNING - OS version detection produced empty result; falling back to BENCHMARK_OS version=${os_maj_ver}"
+fi
+
 audit_content_version=$os_vendor$os_maj_ver-$BENCHMARK-Audit
 audit_content_dir=$AUDIT_CONTENT_LOCATION/$audit_content_version
 audit_vars=vars/${BENCHMARK}.yml


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Hardens `run_audit.sh` OS detection so a pathological `/etc/os-release` cannot silently produce a wrong audit path. Surfaced in a Private-DEBIAN11-CIS pipeline run that emitted `WARNING - the /opt/11-CIS-Audit/goss.yml is not available` (note the missing `DEBIAN` prefix - that path is what you get when `os_vendor` ends up empty). Same fix applied to the DEB11, DEB12, and DEB13 audit scripts for consistency.

Two changes in `run_audit.sh`:

1. Drop `grep -w` from the `^ID=` and `^VERSION_ID=` extractions. The anchor + `=` already constrains the match; `-w` is redundant and silently fails on some non-GNU grep implementations (e.g. ugrep), producing an empty `os_id`.
2. Fall back to the hardcoded `BENCHMARK_OS` constant at the top of the script when detection still produces an empty `os_vendor` or `os_maj_ver`. The audit is single-OS by design, so detection should be a sanity check, not a load-bearing identifier. A clear WARNING line is emitted on stdout when the fallback fires.

**Issue Fixes:**
N/A (no tracking issue filed; ported as a defensive fix alongside the DEB11/DEB12 sibling PRs)

**Enhancements:**
- More portable grep patterns (no dependence on `-w` semantics)
- Defensive fallback prevents silent path corruption
- Clear WARNING on stdout when detection fails

**How has this been tested?:**

End-to-end in real Debian 11 containers (same script logic; DEB13 commits are identical except for `BENCHMARK_OS=DEBIAN13` and `BENCHMARK_VER=1.0.0`), three scenarios:

| Scenario | Vendor | Version | Path | Warnings |
|---|---|---|---|---|
| Clean `/etc/os-release` | DEBIAN | 11 | `/opt/DEBIAN11-CIS-Audit` | none |
| No `ID=` line (CI failure case) | DEBIAN | 11 | `/opt/DEBIAN11-CIS-Audit` | fallback fires for vendor |
| `/etc/os-release` missing | DEBIAN | 11 | `/opt/DEBIAN11-CIS-Audit` | fallback fires for both |

Plus full `molecule converge` on Private-DEBIAN11-CIS against the DEB11 sibling branch: `failed=0`, 395 goss tests ran in both pre and post phases.

The DEB13 commit (`78a56d3`) is byte-identical in the patched block to the DEB11 commit, modulo the hardcoded `BENCHMARK_OS=DEBIAN13` constant.