### PR TITLE
Sept26 updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,21 @@
 # Debian 13 CIS
 
+## Based on CIS v1.0.0 - Branch sept26_updates
+
+- 1.7.2 defined the goss key gdm_profile_banner twice in one command: map, so the
+  banner-message-enable assertion was lost and goss aborts on a duplicate key
+- 1.7.10 and 1.7.11 both keyed on /etc/gdm3/custom.conf; level_1 and level_2 both default
+  true, so goss merged them and 1.7.10 was silently dropped. Both now use named keys
+- 1.6.1, 1.6.2 and 1.6.3 asserted '!/(?i)linux' with no closing /, which goss reads as a
+  literal string, so the OS-disclosure check never fired. Host-proven: all three banner
+  files contained "Debian GNU/Linux" while the audit reported clean
+- 1.1.1.6 checked the non-existent overlayfs module; the FATAL "module not found" message
+  itself contained the string being grepped, so it always passed. Now overlay
+
+- 6.2.3.10 was a placeholder that echoed "Manual" then asserted the output must not contain
+  "Manual", so it could only ever fail and checked nothing. Replaced with conf and running
+  checks on the -k privileged rules, in the POSIX echo-on-failure style used by 6.2.3.9
+
 ## Based on CIS v1.0.0 - Branch align_1.0.0
 
 - 5.4.2.8 used bash process substitution. Goss runs commands under sh, which is dash on Debian,

--- a/section_1/cis_1.1.1.x/cis_1.1.1.6.yml
+++ b/section_1/cis_1.1.1.x/cis_1.1.1.6.yml
@@ -3,10 +3,10 @@
 {{ if .Vars.deb13cis_level_2 }}
   {{ if .Vars.deb13cis_rule_1_1_1_6 }}
 command:
-  overlayfs:
+  overlay:
     title: 1.1.1.6 | Ensure overlay kernel module is not available | disabled
     exit-status: 0
-    exec: "modprobe -n -v overlayfs | grep -E '(overlayfs|install)'"
+    exec: "modprobe -n -v overlay | grep -E '(overlay|install)'"
     stdout:
     - install /bin/true
     meta:
@@ -14,12 +14,12 @@ command:
       workstation: 2
       CIS_ID: 1.1.1.6
       NIST800-53R5: CM-7
-  blacklist_overlayfs:
+  blacklist_overlay:
     title: 1.1.1.6 | Ensure overlay kernel module is not available | blacklist
     exit-status: 0
-    exec: grep overlayfs /etc/modprobe.d/*.conf
+    exec: grep overlay /etc/modprobe.d/*.conf
     stdout:
-      - '/blacklist overlayfs/'
+      - '/blacklist overlay/'
     meta:
       server: 2
       workstation: 2

--- a/section_1/cis_1.6.x/cis_1.6.1.yml
+++ b/section_1/cis_1.6.x/cis_1.6.1.yml
@@ -15,7 +15,7 @@ file:
     - '!/(?i)ubuntu.*/'
     - '!/(?i)kernel.*/'
     - '!/x86_64/'
-    - '!/(?i)linux'
+    - '!/(?i)linux.*/'
     meta:
       server: 1
       workstation: 1

--- a/section_1/cis_1.6.x/cis_1.6.2.yml
+++ b/section_1/cis_1.6.x/cis_1.6.2.yml
@@ -12,7 +12,7 @@ file:
     - '!/(?i)ubuntu.*/'
     - '!/(?i)kernel.*/'
     - '!/x86_64/'
-    - '!/(?i)linux'
+    - '!/(?i)linux.*/'
     - '{{ .Vars.deb13cis_warning_banner }}'
     meta:
       server: 1

--- a/section_1/cis_1.6.x/cis_1.6.3.yml
+++ b/section_1/cis_1.6.x/cis_1.6.3.yml
@@ -12,7 +12,7 @@ file:
     - '!/(?i)ubuntu.*/'
     - '!/(?i)kernel.*/'
     - '!/x86_64/'
-    - '!/(?i)linux'
+    - '!/(?i)linux.*/'
     - '{{ .Vars.deb13cis_warning_banner }}'
     meta:
       server: 1

--- a/section_1/cis_1.7/cis_1.7.10.yml
+++ b/section_1/cis_1.7/cis_1.7.10.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb13cis_level_1 }}
     {{ if .Vars.deb13cis_rule_1_7_10 }}
 file:
-  /etc/gdm3/custom.conf:
+  gdm_xdmcp_disabled:
     title: 1.7.10 | Ensure XDMCP is not enabled
     path: /etc/gdm3/custom.conf
     exists: true

--- a/section_1/cis_1.7/cis_1.7.11.yml
+++ b/section_1/cis_1.7/cis_1.7.11.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.deb13cis_level_2 }}
     {{ if .Vars.deb13cis_rule_1_7_11 }}
 file:
-  /etc/gdm3/custom.conf:
+  gdm_xwayland_config:
     title: 1.7.11 | Ensure Xwayland is configured
     path: /etc/gdm3/custom.conf
     exists: true

--- a/section_1/cis_1.7/cis_1.7.2.yml
+++ b/section_1/cis_1.7/cis_1.7.2.yml
@@ -5,7 +5,7 @@
     {{ if .Vars.deb13cis_rule_1_7_2 }}
 command:
   gdm_profile_banner:
-    title: 1.7.2 | Ensure GDM login banner is configured
+    title: 1.7.2 | Ensure GDM login banner is configured | banner enabled
     exec: gsettings get org.gnome.login-screen banner-message-enable
     exit-status: 0
     stdout:
@@ -21,8 +21,8 @@ command:
       - CM-6
       - CM-7
       - IA-5
-  gdm_profile_banner:
-    title: 1.7.2 | Ensure GDM login banner is configured
+  gdm_profile_banner_text:
+    title: 1.7.2 | Ensure GDM login banner is configured | banner text
     exec: gsettings get org.gnome.login-screen banner-message-text
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3.x/cis_6.2.3.10.yml
+++ b/section_6/cis_6.2.3.x/cis_6.2.3.10.yml
@@ -4,11 +4,26 @@
   {{ if .Vars.deb13cis_rule_6_2_3_10 }}
 command:
   auditd_priv_cmds_cnf:
-    title: 6.2.3.10 | Ensure use of privileged commands are collected | Manual Check Required
-    exec: echo "Manual - Please investigate privilege commands are collected as per documentation"
+    title: 6.2.3.10 | Ensure use of privileged commands are collected | conf check
+    exec: |
+      grep -hsqE -- '^-a always,exit -F path=[^[:space:]]+ -F perm=x -F auid>=[0-9]+ -F auid!=unset -k privileged$' /etc/audit/rules.d/*.rules || echo "MISSING privileged command rules"
     exit-status: 0
     stdout:
-    - '!/Manual/'
+    - '!/./'
+    meta:
+      server: 2
+      workstation: 2
+      CIS_ID:
+      - 6.2.3.10
+      NIST800-53R5:
+      - AU-3
+  auditd_priv_cmds_live:
+    title: 6.2.3.10 | Ensure use of privileged commands are collected | running
+    exec: |
+      auditctl -l 2>/dev/null | grep -E -- 'path=[^[:space:]]+' | grep -E -- 'perm=x' | grep -qE -- '(-k|key=)[[:space:]]?privileged([[:space:]]|$)' || echo "MISSING privileged command rules"
+    exit-status: 0
+    stdout:
+    - '!/./'
     meta:
       server: 2
       workstation: 2


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
- 1.7.2 defined the goss key gdm_profile_banner twice in one command: map, so the
  banner-message-enable assertion was lost and goss aborts on a duplicate key
- 1.7.10 and 1.7.11 both keyed on /etc/gdm3/custom.conf; level_1 and level_2 both default
  true, so goss merged them and 1.7.10 was silently dropped. Both now use named keys
- 1.6.1, 1.6.2 and 1.6.3 asserted '!/(?i)linux' with no closing /, which goss reads as a
  literal string, so the OS-disclosure check never fired. Host-proven: all three banner
  files contained "Debian GNU/Linux" while the audit reported clean
- 1.1.1.6 checked the non-existent overlayfs module; the FATAL "module not found" message
  itself contained the string being grepped, so it always passed. Now overlay

- 6.2.3.10 was a placeholder that echoed "Manual" then asserted the output must not contain
  "Manual", so it could only ever fail and checked nothing. Replaced with conf and running
  checks on the -k privileged rules, in the POSIX echo-on-failure style used by 6.2.3.9

**How has this been tested?:**
Manual testing

